### PR TITLE
fix crash on app close & reopen

### DIFF
--- a/Sources/MapItemPicker/MapItemPickerViewController.swift
+++ b/Sources/MapItemPicker/MapItemPickerViewController.swift
@@ -197,8 +197,8 @@ class MapItemPickerViewController:
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         let name = UIApplication.willEnterForegroundNotification
-        foregroundRestorationObserver = NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil, using: { [unowned self] (_) in
-            self.locationManager.requestWhenInUseAuthorization()
+        foregroundRestorationObserver = NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil, using: { [weak self] (_) in
+            self?.locationManager.requestWhenInUseAuthorization()
         })
         locationManager.requestWhenInUseAuthorization()
         


### PR DESCRIPTION
If the app was closed while the picker was open, it crashed because the `self` was not defined anymore.
This is a simple fix using a `weak self` so the app doesn't just crash anymore.